### PR TITLE
Better rule mapping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.soloplan.oss.sonarqube.plugin.resharper.clt</groupId>
   <artifactId>resharper-clt-plugin</artifactId>
   <packaging>sonar-plugin</packaging>
-  <version>1.0.0.202013</version>
+  <version>1.1.0.202013</version>
 
   <name>ReSharper command line tools plugin for SonarQube 7.9.x LTS</name>
   <description>Enables the use of ReSharper command line tools with rules on C# and VB.NET code.</description>

--- a/src/main/java/com/soloplan/oss/sonarqube/plugin/resharper/clt/converters/InspectCodeIssueDefinitionToSonarQubeRuleDefinitionConverter.java
+++ b/src/main/java/com/soloplan/oss/sonarqube/plugin/resharper/clt/converters/InspectCodeIssueDefinitionToSonarQubeRuleDefinitionConverter.java
@@ -26,7 +26,6 @@ import com.soloplan.oss.sonarqube.plugin.resharper.clt.models.SonarQubeRuleDefin
 import org.apache.commons.lang.StringEscapeUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.sonar.api.rule.RuleStatus;
 
 import java.net.URL;
 import java.util.Collection;
@@ -48,13 +47,10 @@ public class InspectCodeIssueDefinitionToSonarQubeRuleDefinitionConverter
 
     // Create a new instance of the SonarQubeRuleDefinitionModel class and fill in the values of the supplied InspectCode issue definition
     final SonarQubeRuleDefinitionModel ruleDefinitionModel =
-        new SonarQubeRuleDefinitionModel(inspectCodeIssueDefinitionModel.getIssueTypeId());
-    ruleDefinitionModel.setRuleName(inspectCodeIssueDefinitionModel.getDescription());
-    ruleDefinitionModel.setActivatedByDefault(false);
+        new SonarQubeRuleDefinitionModel(inspectCodeIssueDefinitionModel);
     ruleDefinitionModel.setRuleDescription(
         combineRuleDescription(inspectCodeIssueDefinitionModel.getDescription(), inspectCodeIssueDefinitionModel.getWikiUrl()),
         SonarQubeRuleDescriptionSyntax.HTML);
-    ruleDefinitionModel.setRuleStatus(RuleStatus.READY);
     ruleDefinitionModel.setSonarQubeRuleType(convertInspectCodeSeverityToRuleType(inspectCodeIssueDefinitionModel.getSeverity()));
     ruleDefinitionModel.setSonarQubeSeverity(convertInspectCodeSeverityToSonarQubeSeverity(inspectCodeIssueDefinitionModel.getSeverity()));
 

--- a/src/main/java/com/soloplan/oss/sonarqube/plugin/resharper/clt/interfaces/InspectCodeCategoryOverrideProvider.java
+++ b/src/main/java/com/soloplan/oss/sonarqube/plugin/resharper/clt/interfaces/InspectCodeCategoryOverrideProvider.java
@@ -1,0 +1,11 @@
+package com.soloplan.oss.sonarqube.plugin.resharper.clt.interfaces;
+
+import com.soloplan.oss.sonarqube.plugin.resharper.clt.models.InspectCodeCategoryOverrideModel;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+
+public interface InspectCodeCategoryOverrideProvider {
+  @NotNull
+  public Collection<InspectCodeCategoryOverrideModel> getCategoryOverrides();
+}

--- a/src/main/java/com/soloplan/oss/sonarqube/plugin/resharper/clt/models/InspectCodeCategoryOverrideModel.java
+++ b/src/main/java/com/soloplan/oss/sonarqube/plugin/resharper/clt/models/InspectCodeCategoryOverrideModel.java
@@ -1,0 +1,42 @@
+package com.soloplan.oss.sonarqube.plugin.resharper.clt.models;
+
+import org.jetbrains.annotations.NotNull;
+
+public class InspectCodeCategoryOverrideModel extends RuleOverrideBaseModel {
+
+  private final String categoryId;
+
+  public InspectCodeCategoryOverrideModel(@NotNull String categoryId) {
+    this.categoryId = categoryId;
+  }
+
+  public String getCategoryId() {
+    return this.categoryId;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+
+    return categoryId.equals(((InspectCodeCategoryOverrideModel) other).categoryId);
+  }
+
+  @Override
+  public int hashCode() {
+    return categoryId.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return "SonarQubeRuleDefinitionOverrideModel{" +
+            "categoryId='" + categoryId + '\'' +
+            ", sonarQubeRuleType=" + this.getSonarQubeRuleType() +
+            ", sonarQubeSeverity=" + this.getSonarQubeSeverity() +
+            '}';
+  }
+}

--- a/src/main/java/com/soloplan/oss/sonarqube/plugin/resharper/clt/models/RuleOverrideBaseModel.java
+++ b/src/main/java/com/soloplan/oss/sonarqube/plugin/resharper/clt/models/RuleOverrideBaseModel.java
@@ -1,0 +1,84 @@
+package com.soloplan.oss.sonarqube.plugin.resharper.clt.models;
+
+import com.soloplan.oss.sonarqube.plugin.resharper.clt.enumerations.SonarQubeRuleType;
+import com.soloplan.oss.sonarqube.plugin.resharper.clt.enumerations.SonarQubeSeverity;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public abstract class RuleOverrideBaseModel {
+
+  /**
+   * The type of the SonarQube rule.
+   */
+  private SonarQubeRuleType sonarQubeRuleType = SonarQubeRuleType.getDefaultRuleType();
+
+  /**
+   * The SonarQube compatible severity value of the rule.
+   */
+  private SonarQubeSeverity sonarQubeSeverity = SonarQubeSeverity.getDefaultSeverity();
+
+
+  /**
+   * Gets the SonarQube compatible rule type of this rule definition override. Defaults to {@link SonarQubeRuleType#CODE_SMELL} if not
+   * explicitly set via call to {@link #setSonarQubeRuleType(SonarQubeRuleType)}.
+   *
+   * @return The SonarQube compatible rule type of this rule definition override.
+   */
+  public SonarQubeRuleType getSonarQubeRuleType() {
+    return this.sonarQubeRuleType;
+  }
+
+  /**
+   * Sets the SonarQube compatible rule type of this rule definition override.
+   *
+   * @param sonarQubeRuleType The SonarQube compatible rule type to set for this rule definition override.
+   */
+  public void setSonarQubeRuleType(@NotNull SonarQubeRuleType sonarQubeRuleType) {
+    this.sonarQubeRuleType = sonarQubeRuleType;
+  }
+
+  /**
+   * Sets the SonarQube compatible rule type of this rule definition override by parsing the supplied string representation to a matching
+   * enumeration value.
+   *
+   * @param ruleTypeValue The string representation of the {@link SonarQubeRuleType} to set for this rule definition override.
+   */
+  public void setSonarQubeRuleType(@Nullable String ruleTypeValue) {
+    this.sonarQubeRuleType = SonarQubeRuleType.fromRuleTypeValue(ruleTypeValue);
+  }
+
+  /**
+   * Gets the SonarQube compatible severity value of this rule.
+   * <p>
+   * Defaults to {@link SonarQubeSeverity#MAJOR} if not explicitly set via call to {@link #setSonarQubeSeverity(SonarQubeSeverity)}.
+   * </p>
+   *
+   * @return The SonarQube compatible severity value of this rule.
+   */
+  public SonarQubeSeverity getSonarQubeSeverity() {
+    return sonarQubeSeverity;
+  }
+
+  /**
+   * Sets the SonarQube compatible severity value of this rule.
+   * <p>
+   * Although the SonarQube API defines the severity as parameter of class {@link String}, not all values passed in as arguments are valid
+   * and may result in runtime exceptions. This abstraction uses the enumeration {@link SonarQubeSeverity} to ensure, that only valid values
+   * will be used when creating a new rule.
+   * </p>
+   *
+   * @param sonarQubeSeverity The SonarQube compatible severity value for this rule.
+   */
+  public void setSonarQubeSeverity(@NotNull SonarQubeSeverity sonarQubeSeverity) {
+    this.sonarQubeSeverity = sonarQubeSeverity;
+  }
+
+  /**
+   * Sets the severity value of this issue by parsing the supplied {@link String} to its corresponding {@link SonarQubeSeverity} value.
+   *
+   * @param severityValue A {@link String} value that will be parsed to its corresponding {@link SonarQubeSeverity} value and set as the new severity value.
+   */
+  public void setSonarQubeSeverity(@Nullable String severityValue) {
+    this.sonarQubeSeverity = SonarQubeSeverity.fromSeverityValue(severityValue);
+  }
+}

--- a/src/main/java/com/soloplan/oss/sonarqube/plugin/resharper/clt/models/SonarQubeRuleDefinitionModel.java
+++ b/src/main/java/com/soloplan/oss/sonarqube/plugin/resharper/clt/models/SonarQubeRuleDefinitionModel.java
@@ -55,6 +55,8 @@ public final class SonarQubeRuleDefinitionModel {
   /** Indicates, whether the SonarQube rule definition is activated by default or not. */
   private boolean activatedByDefault = false;
 
+  private InspectCodeIssueDefinitionModel inspectcodeModel;
+
   // TODO Create a property for 'Rule tags', that accepts only strings containing the following characters: a-z, 0-9, '+', '-', '#', '.'
 
   // endregion
@@ -69,6 +71,14 @@ public final class SonarQubeRuleDefinitionModel {
    */
   public SonarQubeRuleDefinitionModel(@NotNull String ruleDefinitionKey) {
     this.ruleDefinitionKey = ruleDefinitionKey.trim();
+  }
+
+  public SonarQubeRuleDefinitionModel(@NotNull InspectCodeIssueDefinitionModel model){
+    this.inspectcodeModel = model;
+    this.ruleDefinitionKey = model.getIssueTypeId();
+    this.ruleName = model.getDescription();
+    this.activatedByDefault = false;
+    this.ruleStatus = RuleStatus.READY;
   }
 
   /**
@@ -237,6 +247,10 @@ public final class SonarQubeRuleDefinitionModel {
    */
   public void setActivatedByDefault(boolean activatedByDefault) {
     this.activatedByDefault = activatedByDefault;
+  }
+
+  public InspectCodeIssueDefinitionModel getInspectcodeModel() {
+    return inspectcodeModel;
   }
 
   @Override

--- a/src/main/java/com/soloplan/oss/sonarqube/plugin/resharper/clt/models/SonarQubeRuleDefinitionOverrideModel.java
+++ b/src/main/java/com/soloplan/oss/sonarqube/plugin/resharper/clt/models/SonarQubeRuleDefinitionOverrideModel.java
@@ -25,20 +25,10 @@ import org.jetbrains.annotations.Nullable;
  * A model class that is used to override specific members of the {@link SonarQubeRuleDefinitionModel} based on their {@link
  * #ruleDefinitionKey} when creating new SonarQube rule definitions.
  */
-public class SonarQubeRuleDefinitionOverrideModel {
-
-  // region Member variables
+public class SonarQubeRuleDefinitionOverrideModel extends RuleOverrideBaseModel{
 
   /** The unique identifier of the SonarQube rule. */
   private final String ruleDefinitionKey;
-
-  /** The type of the SonarQube rule. */
-  private SonarQubeRuleType sonarQubeRuleType = SonarQubeRuleType.getDefaultRuleType();
-
-  /** The SonarQube compatible severity value of the rule. */
-  private SonarQubeSeverity sonarQubeSeverity = SonarQubeSeverity.getDefaultSeverity();
-
-  // endregion
 
   /**
    * Creates a new instance of the {@link SonarQubeRuleDefinitionModel} class using the supplied {@code ruleDefinitionKey} to uniquely
@@ -59,74 +49,6 @@ public class SonarQubeRuleDefinitionOverrideModel {
    */
   public String getRuleDefinitionKey() {
     return ruleDefinitionKey;
-  }
-
-  /**
-   * Gets the SonarQube compatible rule type of this rule definition override. Defaults to {@link SonarQubeRuleType#CODE_SMELL} if not
-   * explicitly set via call to {@link #setSonarQubeRuleType(SonarQubeRuleType)}.
-   *
-   * @return The SonarQube compatible rule type of this rule definition override.
-   */
-  public SonarQubeRuleType getSonarQubeRuleType() {
-    return this.sonarQubeRuleType;
-  }
-
-  /**
-   * Sets the SonarQube compatible rule type of this rule definition override.
-   *
-   * @param sonarQubeRuleType
-   *     The SonarQube compatible rule type to set for this rule definition override.
-   */
-  public void setSonarQubeRuleType(@NotNull SonarQubeRuleType sonarQubeRuleType) {
-    this.sonarQubeRuleType = sonarQubeRuleType;
-  }
-
-  /**
-   * Sets the SonarQube compatible rule type of this rule definition override by parsing the supplied string representation to a matching
-   * enumeration value.
-   *
-   * @param ruleTypeValue
-   *     The string representation of the {@link SonarQubeRuleType} to set for this rule definition override.
-   */
-  public void setSonarQubeRuleType(@Nullable String ruleTypeValue) {
-    this.sonarQubeRuleType = SonarQubeRuleType.fromRuleTypeValue(ruleTypeValue);
-  }
-
-  /**
-   * Gets the SonarQube compatible severity value of this rule.
-   * <p>
-   * Defaults to {@link SonarQubeSeverity#MAJOR} if not explicitly set via call to {@link #setSonarQubeSeverity(SonarQubeSeverity)}.
-   * </p>
-   *
-   * @return The SonarQube compatible severity value of this rule.
-   */
-  public SonarQubeSeverity getSonarQubeSeverity() {
-    return sonarQubeSeverity;
-  }
-
-  /**
-   * Sets the SonarQube compatible severity value of this rule.
-   * <p>
-   * Although the SonarQube API defines the severity as parameter of class {@link String}, not all values passed in as arguments are valid
-   * and may result in runtime exceptions. This abstraction uses the enumeration {@link SonarQubeSeverity} to ensure, that only valid values
-   * will be used when creating a new rule.
-   * </p>
-   *
-   * @param sonarQubeSeverity
-   *     The SonarQube compatible severity value for this rule.
-   */
-  public void setSonarQubeSeverity(@NotNull SonarQubeSeverity sonarQubeSeverity) {
-    this.sonarQubeSeverity = sonarQubeSeverity;
-  }
-
-  /**
-   * Sets the severity value of this issue by parsing the supplied {@link String} to its corresponding {@link SonarQubeSeverity} value.
-   *
-   * @param severityValue
-   *     A {@link String} value that will be parsed to its corresponding {@link SonarQubeSeverity} value and set as the new severity value.
-   */
-  public void setSonarQubeSeverity(@Nullable String severityValue) {
-    this.sonarQubeSeverity = SonarQubeSeverity.fromSeverityValue(severityValue);
   }
 
   @Override
@@ -150,8 +72,8 @@ public class SonarQubeRuleDefinitionOverrideModel {
   public String toString() {
     return "SonarQubeRuleDefinitionOverrideModel{" +
         "ruleDefinitionKey='" + ruleDefinitionKey + '\'' +
-        ", sonarQubeRuleType=" + sonarQubeRuleType +
-        ", sonarQubeSeverity=" + sonarQubeSeverity +
+        ", sonarQubeRuleType=" + getSonarQubeRuleType() +
+        ", sonarQubeSeverity=" + getSonarQubeSeverity() +
         '}';
   }
 }

--- a/src/main/resources/com/jetbrains/resharper/inspectcode/sonarqube_rule_overrides.xml
+++ b/src/main/resources/com/jetbrains/resharper/inspectcode/sonarqube_rule_overrides.xml
@@ -17,6 +17,7 @@
 <Overrides xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation=""  xmlns="urn:/com/soloplan/oss/sonarqube/plugin/resharper/clt/xml">
   <InspectCodeCategoryOverride InspectCodeCategoryId="BestPractice" SonarRuleType="CODE_SMELL" />
   <InspectCodeCategoryOverride InspectCodeCategoryId="CodeInfo" SonarRuleType="CODE_SMELL" />
+  <InspectCodeCategoryOverride InspectCodeCategoryId="CodeRedundancy" SonarRuleType="CODE_SMELL" />
   <InspectCodeCategoryOverride InspectCodeCategoryId="CodeSmell" SonarRuleType="CODE_SMELL" />
   <InspectCodeCategoryOverride InspectCodeCategoryId="CodeStyleIssues" SonarRuleType="CODE_SMELL" />
   <InspectCodeCategoryOverride InspectCodeCategoryId="DeclarationRedundancy" SonarRuleType="CODE_SMELL" />

--- a/src/main/resources/com/jetbrains/resharper/inspectcode/sonarqube_rule_overrides.xml
+++ b/src/main/resources/com/jetbrains/resharper/inspectcode/sonarqube_rule_overrides.xml
@@ -15,6 +15,17 @@
   ~    limitations under the License.
   -->
 <Overrides xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation=""  xmlns="urn:/com/soloplan/oss/sonarqube/plugin/resharper/clt/xml">
+  <InspectCodeCategoryOverride InspectCodeCategoryId="BestPractice" SonarRuleType="CODE_SMELL" />
+  <InspectCodeCategoryOverride InspectCodeCategoryId="CodeInfo" SonarRuleType="CODE_SMELL" />
+  <InspectCodeCategoryOverride InspectCodeCategoryId="CodeSmell" SonarRuleType="CODE_SMELL" />
+  <InspectCodeCategoryOverride InspectCodeCategoryId="CodeStyleIssues" SonarRuleType="CODE_SMELL" />
+  <InspectCodeCategoryOverride InspectCodeCategoryId="DeclarationRedundancy" SonarRuleType="CODE_SMELL" />
+  <InspectCodeCategoryOverride InspectCodeCategoryId="FormattingIssues" SonarRuleType="CODE_SMELL" />
+  <InspectCodeCategoryOverride InspectCodeCategoryId="LanguageUsage" SonarRuleType="CODE_SMELL" />
+  <InspectCodeCategoryOverride InspectCodeCategoryId="NUnit" SonarRuleType="CODE_SMELL" />
+  <InspectCodeCategoryOverride InspectCodeCategoryId="Spelling" SonarRuleType="CODE_SMELL" />
+  <InspectCodeCategoryOverride InspectCodeCategoryId="XUnit" SonarRuleType="CODE_SMELL" />
+
   <SonarRuleOverride SonarRuleKey="ArrangeThisQualifier" SonarRuleType="CODE_SMELL" SonarSeverity="MINOR"/>
   <SonarRuleOverride SonarRuleKey="CheckNamespace" SonarRuleType="CODE_SMELL" SonarSeverity="MINOR"/>
   <SonarRuleOverride SonarRuleKey="CSharpWarnings::CS0618" SonarRuleType="CODE_SMELL" SonarSeverity="MAJOR"/>

--- a/src/main/resources/com/soloplan/oss/sonarqube/plugin/resharper/clt/xml/sonarqube_rule_overrides-schema_definition.xsd
+++ b/src/main/resources/com/soloplan/oss/sonarqube/plugin/resharper/clt/xml/sonarqube_rule_overrides-schema_definition.xsd
@@ -25,10 +25,12 @@
 
   <!-- Defines an XML element consisting of zero to unlimited elements named 'SonarRuleOverride' -->
   <xs:complexType name="OverridesType">
-    <xs:sequence>
+    <xs:all>
+      <xs:element name="InspectCodeCategoryOverride" minOccurs="0" type="plugin:InspectCodeCategoryOverrideType"/>
+
       <!-- This element represents a 'SonarRuleOverride', the issue definition dump and report XML files -->
       <xs:element name="SonarRuleOverride" minOccurs="0" type="plugin:SonarRuleOverrideType"/>
-    </xs:sequence>
+    </xs:all>
   </xs:complexType>
 
   <!-- Complex type definition named 'SonarRuleOverride' used above, consisting of simple data types as attributes -->
@@ -36,6 +38,17 @@
     <xs:simpleContent>
       <xs:extension base="xs:string">
         <xs:attribute name="SonarRuleKey" type="xs:string" use="required"/>
+        <xs:attribute name="SonarRuleType" type="plugin:SonarRuleTypeAttributeType"/> <!-- optional -->
+        <xs:attribute name="SonarSeverity" type="plugin:SonarSeverityAttributeType"/> <!-- optional -->
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!-- Complex type definition named 'SonarRuleOverride' used above, consisting of simple data types as attributes -->
+  <xs:complexType name="InspectCodeCategoryOverrideType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="InspectCodeCategoryId" type="plugin:InspectCodeCategoryIdAttributeType" use="required"/>
         <xs:attribute name="SonarRuleType" type="plugin:SonarRuleTypeAttributeType"/> <!-- optional -->
         <xs:attribute name="SonarSeverity" type="plugin:SonarSeverityAttributeType"/> <!-- optional -->
       </xs:extension>
@@ -63,6 +76,26 @@
       <xs:enumeration value="BUG"/>
       <xs:enumeration value="VULNERABILITY"/>
       <xs:enumeration value="CODE_SMELL"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- This type defines all valid values of the 'SonarRuleType' attribute within the 'IssueTypeOverride' element.
+     For details, visit: http://javadocs.sonarsource.org/6.7/apidocs/org/sonar/api/rules/RuleType.html -->
+  <xs:simpleType name="InspectCodeCategoryIdAttributeType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="BestPractice"/>
+      <xs:enumeration value="CodeInfo"/>
+      <xs:enumeration value="CodeSmell"/>
+      <xs:enumeration value="CodeStyleIssues"/>
+      <xs:enumeration value="CodeRedundancy"/>
+      <xs:enumeration value="CompilerWarnings"/>
+      <xs:enumeration value="ConstraintViolation"/>
+      <xs:enumeration value="DeclarationRedundancy"/>
+      <xs:enumeration value="FormattingIssues"/>
+      <xs:enumeration value="LanguageUsage"/>
+      <xs:enumeration value="NUnit"/>
+      <xs:enumeration value="Spelling"/>
+      <xs:enumeration value="XUnit"/>
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
These changes allow configuring the SonarQube rule type by Inspectcode `CategoryId`.

This means, that it's now possible via configuration to define whether a rule of a certain category should e.g. be a `Bug` or `Code Smell`. This setting will be overwritten by individually specified rule overrides from the XML.

This will drastically reduce the number of issues that are categorized as bugs even though they are actually just code-smells.